### PR TITLE
fix: resolve duplicated after sync

### DIFF
--- a/src/components/codemirror/index.tsx
+++ b/src/components/codemirror/index.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx"
-import { memo, useCallback, useEffect, useMemo, useRef } from "react"
+import { memo, useEffect, useMemo, useRef } from "react"
 import { EditorView, keymap } from "@codemirror/view"
 import { indentWithTab } from "@codemirror/commands"
 import { basicSetup } from "codemirror"
@@ -15,7 +15,6 @@ import { UndoManager } from "yjs"
 import cache from "@/lib/fs/cache"
 // @ts-ignore
 import { yCollab } from "y-codemirror.next"
-import { fromSource } from "@/lib/fs/model"
 
 type CodemirrorProps = {
   className?: string
@@ -52,12 +51,11 @@ const Codemirror = memo((props: CodemirrorProps) => {
     useCommonConfigurationExtension(cm),
   )
 
-  const buildStaticSourceforCache = useCallback(() => fromSource(props.source), [props.source])
   const cacheUpdateListenerExtension = useMemo(
     () =>
       EditorView.updateListener.of((e) => {
         if (!e.docChanged) return
-        cache.debouncedUpdateCache(props.source.id, buildStaticSourceforCache)
+        cache.debouncedUpdateCache(props.source.id, () => props.source.serialize())
       }),
     [props.source],
   )

--- a/src/hooks/useY.ts
+++ b/src/hooks/useY.ts
@@ -1,7 +1,7 @@
 import { Getter } from "jotai"
 import { atomWithObservable } from "jotai/utils"
 import { useEffect, useState } from "react"
-import { Text, Array, AbstractType, Map, Doc } from "yjs"
+import { Text, Array, AbstractType, Map, Doc, encodeStateAsUpdateV2, applyUpdateV2 } from "yjs"
 
 export function createYjsHook<T, V extends AbstractType<any>>(initialValue: T, observer: V, updater: (y: V) => T): T {
   const [content, setContent] = useState(initialValue)
@@ -66,6 +66,7 @@ export function useYMap<V>(ymap: Map<V>) {
 export class YjsNS {
   doc: Doc
   id: string
+
   public constructor(doc: Doc, id: string) {
     const map = doc.getMap()
     this.id = id
@@ -76,6 +77,7 @@ export class YjsNS {
       map.set(id, this.doc)
     }
     doc.load()
+
   }
 
   public destroy() {
@@ -155,5 +157,12 @@ export class YjsNS {
   }
   public useMap(name: string) {
     return useYMap(this.getMap(name))
+  }
+
+  public encode(): Uint8Array{
+    return encodeStateAsUpdateV2(this.doc)
+  }
+  public decode(data: Uint8Array){
+    applyUpdateV2(this.doc, data)
   }
 }

--- a/src/lib/fs/model.ts
+++ b/src/lib/fs/model.ts
@@ -21,7 +21,13 @@ export interface StaticSourceData {
   readonly tests: StaticTestData[]
 }
 
-export function fromSource(source: Source): StaticSourceData {
+/**
+ * Get data from Yjs
+ * this would lost all history info
+ * @param source 
+ * @returns 
+ */
+export function intoStaticSource(source: Source): StaticSourceData {
   return {
     id: source.id,
     name: source.name.toString(),
@@ -53,7 +59,7 @@ export function fromSource(source: Source): StaticSourceData {
  * Attation: it would not change the id of source object,
  * if you want to specify its id, use store.create plz
  */
-export function intoSource(
+export function fillSource(
   data: StaticSourceData,
   source: Source,
   defaultTimeLimit: number = 5000,

--- a/src/lib/fs/problem.ts
+++ b/src/lib/fs/problem.ts
@@ -6,8 +6,8 @@ import { parse, right } from "../parse"
 import { capitalize } from "lodash"
 import { map, __, flatten, zip, range } from "lodash/fp"
 import { crc16 } from "crc"
-import { StaticSourceData, StaticTestData } from "./model"
 import {v4 as uuid} from 'uuid'
+import { StaticSourceData, StaticTestData } from "./model"
 
 /**
  * get language mode from file extension name

--- a/src/pages/Main/event/index.tsx
+++ b/src/pages/Main/event/index.tsx
@@ -1,11 +1,11 @@
-import CacheLoader from "./cache-loader"
 import MenuEventReceiver from "./menu-event"
+import useAutoSaveLoader from "./useAutoSaveLoader"
 
 export default function MainEventRegister() {
+  useAutoSaveLoader()
   return (
     <>
       <MenuEventReceiver />
-      <CacheLoader />
       {/* <StatusRecover /> */}
     </>
   )

--- a/src/pages/Main/event/menu-event.tsx
+++ b/src/pages/Main/event/menu-event.tsx
@@ -1,5 +1,4 @@
 import { useMitt } from "@/hooks/useMitt"
-import { fromSource } from "@/lib/fs/model"
 import { openProblem, saveProblem } from "@/lib/fs/problem"
 import { defaultLanguageAtom, defaultMemoryLimitsAtom, defaultTimeLimitsAtom } from "@/store/setting/setup"
 import { activedSourceAtom, createSourceAtom, sourceAtom } from "@/store/source"
@@ -9,6 +8,7 @@ import { useAtomValue, useSetAtom } from "jotai"
 import { LocalSourceMetadata, getSourceMetaAtom, setSourceMetaAtom } from "@/store/source/local"
 import { crc16 } from "crc"
 import { zip } from "lodash/fp"
+import { intoStaticSource } from "@/lib/fs/model"
 
 /**
  * Save source to file
@@ -39,7 +39,7 @@ async function saveFile(source: Source, getSaveTarget?: (id: string) => string |
 
   // if it is null, that's means user cancel operation
   if (file) {
-    const staticSourceData = fromSource(source)
+    const staticSourceData = intoStaticSource(source)
     await saveProblem(staticSourceData, file)
   }
 }
@@ -109,3 +109,4 @@ export default function MenuEventReceiver() {
 
   return null
 }
+

--- a/src/pages/Main/event/useAutoSaveLoader.tsx
+++ b/src/pages/Main/event/useAutoSaveLoader.tsx
@@ -4,7 +4,6 @@ import cache from "@/lib/fs/cache"
 import useReadAtom from "@/hooks/useReadAtom"
 import { sourceAtom } from "@/store/source"
 import { forEach } from "lodash/fp"
-import { StaticSourceData } from "@/lib/fs/model"
 
 const alreadyLoadedAtom = atom(false)
 /**
@@ -12,7 +11,7 @@ const alreadyLoadedAtom = atom(false)
  * It only be execuate on startup
  */
 
-export default function CacheLoader() {
+export default function useAutoSaveLoader() {
   const [alreadyLoaded, setAlreadyLoaded] = useAtom(alreadyLoadedAtom)
   const currentLoaded = useRef(false)
   const readSourceStore = useReadAtom(sourceAtom)
@@ -24,10 +23,9 @@ export default function CacheLoader() {
       const store = readSourceStore()
       cache.loadAll().then((data) => {
         store.doc.transact(() => {
-          forEach((v: StaticSourceData)=>store.createFromStatic(v, v.id), data)
+          forEach((v)=>store.createByDeserialization(v.data, v.id), data)
         })
       })
     }
   }, [alreadyLoaded])
-  return null
 }

--- a/src/store/source/index.ts
+++ b/src/store/source/index.ts
@@ -6,7 +6,6 @@ import * as log from "tauri-plugin-log-api"
 import { LanguageMode } from "@/lib/ipc"
 import { createYjsHookAtom } from "@/hooks/useY"
 import cache from "@/lib/fs/cache"
-import { fromSource } from "@/lib/fs/model"
 import generateRandomName from "@/lib/names"
 
 export const docAtom = atom(new Doc())
@@ -84,7 +83,7 @@ export const createSourceAtom = atom(
       log.info(`create new source: ${id}`)
       log.info(JSON.stringify(get(sourceIdsAtom)))
     })
-    cache.updateCache(id, () => fromSource(source))
+    cache.updateCache(id, ()=>source.serialize())
     return source
   },
 )
@@ -120,7 +119,7 @@ export const duplicateSourceAtom = atom(null, (get, set, id: string, newName: (o
       )
     })
 
-    cache.updateCache(newSource.id, () => fromSource(newSource))
+    cache.updateCache(newSource.id, ()=>newSource.serialize())
     return newSource
   } else {
     return null


### PR DESCRIPTION
The problem was caused by serialization when auto saving. The serialization would lost all history before, so the recover and sync would create a duplicated file.

BREAKING CHANGE: The format of auto saving file was changed, so the old file can not be loaded